### PR TITLE
Add icache_miss_stall metric

### DIFF
--- a/tools/metric_icache_miss_stalls
+++ b/tools/metric_icache_miss_stalls
@@ -1,0 +1,67 @@
+#!/bin/bash -x
+
+# Copyright (C) 2018 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, 
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+# OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+SCRIPTS_DIR=`dirname $0`
+source ${SCRIPTS_DIR}/utils.sh
+
+function init_icache_miss_stalls() {
+  #Comma seperated perf supported counter names. See example below"
+  local local_pmu_array=(instructions icache_16b.ifdata_stall
+          "cpu/event=0x80,umask=0x4,cmask=1,edge=1,name=iicache_16b.ifdata_stall:c1:e1/")
+  for item in ${local_pmu_array[*]}
+  do
+    if [ "x${local_pmus}" == "x" ]; then
+      local_pmus="$item"
+    else
+      local_pmus="$local_pmus,$item"
+    fi
+  done
+  echo $local_pmus
+}
+
+function calc_icache_miss_stalls() {
+  local perf_data_file="$1"
+  echo
+  echo "================================================="
+  echo "Final icache_miss_stall metric"
+  echo "--------------------------------------------------"
+  echo "FORMULA: metric_ICache_Misses(%) = 100*((a+2*b)/c)"
+  echo "         where, a=icache_16b.ifdata_stall"
+  echo "                b=icache_16b.ifdata_stall:c1:e1)"
+  echo "                c=cycles"
+  echo "================================================="
+
+  local a=`return_pmu_value "icache_16b.ifdata_stall" ${perf_data_file}`
+  local b=`return_pmu_value "iicache_16b.ifdata_stall:c1:e1" ${perf_data_file}`
+  local c=`return_pmu_value "cycles" ${perf_data_file}`
+    
+  if [ $a == -1 -o $b == -1 -o $c == -1 ]; then
+    echo "ERROR: metric_ICache_Misses can't be derived. Missing pmus"
+  else
+    local metric=`echo "scale=$bc_scale;100*((${a}+2*${b})/${c})"| bc -l`
+    echo "metric_ICache_Misses(%)=${metric}"
+  fi
+
+}


### PR DESCRIPTION
New metric for icache_miss_stall

For perf to work with icache_16b.ifdata_stall:c1:e1 we need to use the event in the following format

cpu/event=0x80,umask=0x4,cmask=1,edge=1,name=iicache_16b.ifdata_stall:c1:e1/

https://download.01.org/perfmon/SKX/skylakex_core_v1.18.json shows 0x80 with umask 0x4 for icache_16b.ifdata_stall
