### PR TITLE
Bring CPP implementation into line with the C one

### DIFF
--- a/large_page/Makefile
+++ b/large_page/Makefile
@@ -1,7 +1,7 @@
 all: liblarge_page.a
 
 CC=g++
-CFLAGS=-O3 -D_FORTIFY_SOURCE=2 -fsanitize=address -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
+CFLAGS=-O3 -std=c++11 -D_FORTIFY_SOURCE=2 -fsanitize=address -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
 AR=ar
 RM=/bin/rm
 

--- a/large_page/example/Makefile
+++ b/large_page/example/Makefile
@@ -1,15 +1,16 @@
 OBJDIR = obj
 OBJS = $(addprefix $(OBJDIR)/,large_page_example.o large_page.o)
-LDFLAGS = -Wl,-T ../ld.implicit.script
+CPPFLAGS=-O3 -std=c++11 -D_FORTIFY_SOURCE=2 -fsanitize=address -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
+LDFLAGS = -Wl,-T ../ld.implicit.script -fsanitize=address
 VPATH =  %.cc ..
 
 all: large_page_example
 
 large_page_example: $(OBJS)
-	@g++ $(OBJS) -Wl,-T ../ld.implicit.script -o $@
+	@g++ $(OBJS) $(LDFLAGS) -o $@
 
 $(OBJDIR)/%.o : %.cc
-	@g++ -o $@ -c -I.. $<
+	@g++ $(CPPFLAGS) -o $@ -c -I.. $<
 
 $(OBJS): | $(OBJDIR)
 

--- a/large_page/example/large_page_example.cc
+++ b/large_page/example/large_page_example.cc
@@ -1,11 +1,31 @@
 #include <iostream>
 #include "large_page.h"
 
-int main()
-{
-   if (IsLargePagesEnabled())
-     std::cout<<"Transparent Huge Pages is enabled"<<std::endl;
-   else
-     std::cout<<"Transparent Huge Pages is not enabled"<<std::endl;
-   return 0;
+using std::cout;
+using std::cerr;
+using std::endl;
+
+int main() {
+  largepage::MapStatus status;
+  bool is_enabled;
+
+  status = largepage::IsLargePagesEnabled(&is_enabled);
+  if (status != largepage::map_ok) {
+    cerr << "Failed to check enablement: "
+         << largepage::MapStatusStr(status) << endl;
+    return status;
+  }
+
+  if (is_enabled) {
+    cout << "Transparent Huge Pages are enabled, mapping ..." << endl;
+    status = largepage::MapStaticCodeToLargePages();
+    if (status != largepage::map_ok) {
+      cerr << "Failed to map: " << largepage::MapStatusStr(status) << endl;
+      return status;
+    }
+    cout << "Success !" << endl;
+    return 0;
+  }
+  cerr << "Transparent Huge Pages are not enabled" << endl;
+  return -1;
 }

--- a/large_page/large_page.cc
+++ b/large_page/large_page.cc
@@ -20,76 +20,83 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include "large_page.h"
+
 #include <sys/mman.h>
 #include <unistd.h>
 #include <climits>
 #include <cstring>
+#include <iostream>
 #include <fstream>
 #include <sstream>
+#include <regex>
 #include <inttypes.h>
 
-extern char __textsegment;
+extern char __attribute__((weak))  __textsegment;
 
-struct text_region {
-  char* from;
-  char* to;
-  size_t   total_largepages;
-  bool  found_text_region;
+namespace largepage {
+
+  using std::pair;
+  using std::string;
+  using std::ifstream;
+  using std::istringstream;
+  using std::cout;
+  using std::cerr;
+  using std::regex;
+  using std::smatch;
+
+
+namespace {
+
+struct MemRange {
+  void*     from;
+  void*     to;
+  MemRange() : from(nullptr), to(nullptr) {}
+  MemRange(void* from, void* to) : from(from), to(to) {}
+  void set(void* f, void* t) { from = f; to = t; }
 };
 
-static const size_t hps = 2L * 1024 * 1024;
+constexpr size_t hps = 2L * 1024 * 1024;
 
-static void PrintSystemError(int error) {
-  fprintf(stderr, "Hugepages WARNING: %s\n", strerror(error));
-  return;
+constexpr uintptr_t LargePageAlignDown(uintptr_t addr) {
+  return (addr & ~(hps - 1));
 }
 
-static inline uintptr_t largepage_align_up(uintptr_t addr) {
-  return (((addr) + (hps) - 1) & ~((hps) - 1));
-}
-
-static inline uintptr_t largepage_align_down(uintptr_t addr) {
-  return ((addr) & ~((hps) - 1));
+constexpr uintptr_t LargePageAlignUp(uintptr_t addr) {
+  return LargePageAlignDown(addr + hps - 1);
 }
 
 // Identify and return the text region in the currently mapped memory regions.
-static struct text_region FindTextRegion() {
-  std::ifstream ifs;
-  std::string map_line;
-  std::string permission;
-  std::string dev;
-  char dash;
-  uintptr_t  start, end, offset, inode;
-  struct text_region nregion;
+MapStatus FindTextRegion(MemRange* region, const string& regexpr = "") {
+  string exename;
+  string map_line;
+  regex lib_regex(regexpr);
+  bool result;
+  char selfexe[PATH_MAX] = {0};
 
-  nregion.from = NULL;
-  nregion.to = NULL;
-  nregion.total_largepages = 0;
-  nregion.found_text_region = false;
+  ifstream ifs("/proc/self/maps");
 
-  ifs.open("/proc/self/maps");
   if (!ifs) {
-    fprintf(stderr, "Could not open /proc/self/maps\n");
-    return nregion;
+    return map_maps_open_failed;
   }
 
-  std::string exename;
-  {
-      char selfexe[PATH_MAX];
-      const char * path = "/proc/self/exe";
-      ssize_t count = readlink(path, selfexe, PATH_MAX);
-      if (count < 0) {
-        fprintf(stderr, "Failed to read the contents of the link: %s", path);
-        return nregion;
-      }
-      exename = std::string(selfexe, count);
+  ssize_t count = readlink("/proc/self/exe", selfexe, PATH_MAX);
+  if (count < 0) {
+    return map_exe_path_read_failed;
   }
+  exename.assign(selfexe, count);
 
-  // The following is the format of the maps file
-  // address           perms offset  dev   inode       pathname
-  // 00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dbus-daemon
-  while (std::getline(ifs, map_line)) {
-    std::istringstream iss(map_line);
+// The following is the format of the maps file
+// address           perms offset  dev   inode       pathname
+// 00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dbus-daemon
+  while (getline(ifs, map_line)) {
+    string permission;
+    string dev;
+    char dash;
+    uint64_t offset, inode;
+    uintptr_t start, end;
+
+    istringstream iss(map_line);
     iss >> std::hex >> start;
     iss >> dash;
     iss >> std::hex >> end;
@@ -97,55 +104,57 @@ static struct text_region FindTextRegion() {
     iss >> offset;
     iss >> dev;
     iss >> inode;
-    if (inode != 0) {
-      std::string pathname;
-      iss >> pathname;
-      if ( !pathname.empty() && pathname == exename && permission == "r-xp" &&
-          start <= reinterpret_cast<int64_t>(&__textsegment) &&
-	  end >= reinterpret_cast<int64_t>(&__textsegment)) {
-        char* from = &__textsegment;
-        char* to = reinterpret_cast<char*>(end);
 
-        if (from < to) {
-          nregion.found_text_region = true;
-          nregion.from = from;
-          nregion.to = to;
-        }
-        break;
+    if (inode != 0 && permission == "r-xp") {
+      string pathname;
+      iss >> pathname;
+      if (regexpr.size() == 0) {
+        result = (pathname == exename &&
+                  start <= (uintptr_t)(&__textsegment) &&
+                  end >= (uintptr_t)(&__textsegment));
+        start = (uintptr_t)(&__textsegment);
+      } else {
+        smatch lib_match;
+        result = regex_search(pathname, lib_match, lib_regex);
+      }
+      if (result) {
+        region->set(reinterpret_cast<void*>(start),
+                    reinterpret_cast<void*>(end));
+        return map_ok;
       }
     }
   }
-
-  ifs.close();
-  return nregion;
+  return map_region_not_found;
 }
 
-static bool IsTransparentHugePagesEnabled() {
-  std::ifstream ifs;
-
-  ifs.open("/sys/kernel/mm/transparent_hugepage/enabled");
+MapStatus IsTransparentHugePagesEnabled(bool* result) {
+  *result = false;
+  ifstream ifs("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!ifs) {
-    fprintf(stderr, "Could not open file: " \
-                    "/sys/kernel/mm/transparent_hugepage/enabled\n");
-    return false;
+    return map_failed_to_open_thp_file;
   }
 
-  std::string always, madvise, never;
-  if (ifs.is_open()) {
-    while (ifs >> always >> madvise >> never) {}
+  string always;
+  string madvise;
+  string never;
+
+  pair<string*, bool> check_items[] = {{ &always, true },
+                                       { &madvise, true },
+                                       { &never, false }};
+
+  ifs >> always >> madvise >> never;
+
+  for (auto check : check_items) {
+    if (check.first->size() == 0) {
+      return map_malformed_thp_file;
+    }
+
+    if (*(check.first->begin()) == '[' && *(check.first->rbegin()) == ']') {
+      *result = check.second;
+      break;
+    }
   }
-
-  int ret_status = false;
-
-  if (always.compare("[always]") == 0)
-    ret_status = true;
-  else if (madvise.compare("[madvise]") == 0)
-    ret_status = true;
-  else if (never.compare("[never]") == 0)
-    ret_status = false;
-
-  ifs.close();
-  return ret_status;
+  return map_ok;
 }
 
 // Move specified region to large pages. We need to be very careful.
@@ -160,111 +169,123 @@ static bool IsTransparentHugePagesEnabled() {
 //    the same virtual address
 // c. madvise with MADV_HUGE_PAGE
 // d. If successful copy the code there and unmap the original region
-static int
+MapStatus
 __attribute__((__section__(".lpstub")))
 __attribute__((__aligned__(hps)))
 __attribute__((__noinline__))
-MoveRegionToLargePages(const text_region& r) {
+MoveRegionToLargePages(const MemRange& r) {
   void* nmem = nullptr;
   void* tmem = nullptr;
   int ret = 0;
-
-  size_t size = r.to - r.from;
-  if (size < 0) {
-    fprintf(stderr, "Size of text segment is invalid (negative)\n");
-    return -1;
-  }
-
+  MapStatus status = map_ok;
   void* start = r.from;
+  size_t size = reinterpret_cast<size_t>(r.to) -
+                reinterpret_cast<size_t>(r.from);
 
-  // Allocate temporary region preparing for copy
+// Allocate temporary region preparing for copy
   nmem = mmap(nullptr, size,
               PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (nmem == MAP_FAILED) {
-    PrintSystemError(errno);
-    return -1;
+    return map_see_errno;
   }
 
   memcpy(nmem, r.from, size);
 
-  // We already know the original page is r-xp
-  // (PROT_READ, PROT_EXEC, MAP_PRIVATE)
-  // We want PROT_WRITE because we are writing into it.
-  // We want it at the fixed address and we use MAP_FIXED.
+// We already know the original page is r-xp
+// (PROT_READ, PROT_EXEC, MAP_PRIVATE)
+// We want PROT_WRITE because we are writing into it.
+// We want it at the fixed address and we use MAP_FIXED.
+#define CLEAN_EXIT_CHECK(oper)                          \
+  if (tmem == MAP_FAILED) {                             \
+    status = oper##_failed;                             \
+    ret = munmap(nmem, size);                           \
+    if (ret < 0) {                                      \
+      status = oper##_munmap_nmem_failed;               \
+    }                                                   \
+    return status;                                      \
+  }
+
   tmem = mmap(start, size,
               PROT_READ | PROT_WRITE | PROT_EXEC,
               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1 , 0);
-  if (tmem == MAP_FAILED) {
-    PrintSystemError(errno);
-    ret = munmap(nmem, size);
-    if (ret < 0) {
-      PrintSystemError(errno);
-      return ret;
-    }
-    return -1;
+CLEAN_EXIT_CHECK(map_see_errno_mmap_tmem);
+
+#undef CLEAN_EXIT_CHECK
+
+#define CLEAN_EXIT_CHECK(oper)                          \
+  if (ret < 0) {                                        \
+    status = oper##_failed;                             \
+    ret = munmap(tmem, size);                           \
+    if (ret < 0) {                                      \
+      status = oper##_munmap_tmem_failed;               \
+    }                                                   \
+    ret = munmap(nmem, size);                           \
+    if (ret < 0) {                                      \
+      status = (status == oper##_munmap_tmem_failed)    \
+        ? oper##_munmaps_failed                         \
+        : oper##_munmap_nmem_failed;                    \
+    }                                                   \
+    return status;                                      \
   }
 
   ret = madvise(tmem, size, MADV_HUGEPAGE);
-  if (ret < 0) {
-    PrintSystemError(errno);
-    ret = munmap(tmem, size);
-    if (ret < 0) {
-      PrintSystemError(errno);
-    }
-    ret = munmap(nmem, size);
-    if (ret < 0) {
-      PrintSystemError(errno);
-    }
-
-    return ret;
-  }
+  CLEAN_EXIT_CHECK(map_see_errno_madvise_tmem);
 
   memcpy(start, nmem, size);
   ret = mprotect(start, size, PROT_READ | PROT_EXEC);
-  if (ret < 0) {
-    PrintSystemError(errno);
-    ret = munmap(tmem, size);
-    if (ret < 0) {
-      PrintSystemError(errno);
-    }
-    ret = munmap(nmem, size);
-    if (ret < 0) {
-      PrintSystemError(errno);
-    }
-    return ret;
-  }
+  CLEAN_EXIT_CHECK(map_see_errno_mprotect);
+
+#undef CLEAN_EXIT_CHECK
 
   // Release the old/temporary mapped region
   ret = munmap(nmem, size);
   if (ret < 0) {
-    PrintSystemError(errno);
+    status = map_see_errno_munmap_nmem_failed;
   }
 
-  return ret;
+  return status;
 }
 
 // Align the region to to be mapped to 2MB page boundaries.
-static void AlignRegionToPageBoundary(text_region& r) {
-  r.from = reinterpret_cast<char*>(largepage_align_up(reinterpret_cast<int64_t>(r.from)));
-  r.to = reinterpret_cast<char*>(largepage_align_down(reinterpret_cast<int64_t>(r.to)));
-  r.total_largepages = (r.to - r.from) / hps;
+void AlignRegionToPageBoundary(MemRange* r) {
+  r->from = reinterpret_cast<void*>(LargePageAlignUp(
+                      reinterpret_cast<uintptr_t>(r->from)));
+  r->to = reinterpret_cast<void*>(LargePageAlignDown(
+                      reinterpret_cast<uintptr_t>(r->to)));
+}
+
+MapStatus CheckMemRange(const MemRange& r) {
+  if (r.from == nullptr || r.to == nullptr || r.from > r.to) {
+    return map_invalid_region_address;
+  }
+
+  if (reinterpret_cast<size_t>(r.to) -
+      reinterpret_cast<size_t>(r.from) < hps) {
+    return map_region_too_small;
+  }
+
+  return map_ok;
 }
 
 // Align the region to to be mapped to 2MB page boundaries and then move the
 // region to large pages.
-static int AlignMoveRegionToLargePages(text_region& r) {
-  AlignRegionToPageBoundary(r);
+MapStatus AlignMoveRegionToLargePages(MemRange r) {
+  AlignRegionToPageBoundary(&r);
 
-  if (r.total_largepages < 1) {
-    fprintf(stderr, "Hugepages WARNING: region is too small for large pages\n");
-    return -1;
+  MapStatus status = CheckMemRange(r);
+  if (status != map_ok) {
+    return status;
   }
 
-  if (r.from > reinterpret_cast<void*>(&MoveRegionToLargePages))
+  if (r.from > (void*)MoveRegionToLargePages ||
+      r.to <= (void*)MoveRegionToLargePages) {
     return MoveRegionToLargePages(r);
+  }
 
-  return -1;
+  return map_mover_overlaps;
 }
+
+}  // namespace
 
 // Map the .text segment of the linked application into 2MB pages.
 // The algorithm is simple:
@@ -282,35 +303,77 @@ static int AlignMoveRegionToLargePages(text_region& r) {
 //    * Use madvise with MADV_HUGE_PAGE to use anonymous 2M pages.
 //    * If successful, copy the code to the newly mapped area and unmap the
 //      original region.
-int MapStaticCodeToLargePages() {
-  struct text_region r = FindTextRegion();
-  if (r.found_text_region == false) {
-    fprintf(stderr, "Hugepages WARNING: failed to find text region\n");
-    return -1;
+MapStatus MapStaticCodeToLargePages(const std::string& regexpr) {
+  MemRange r;
+  MapStatus status = FindTextRegion(&r, regexpr);
+  if (status != map_ok) {
+    return status;
   }
-
   return AlignMoveRegionToLargePages(r);
 }
 
-// This function is similar to the function above. However, the region to be 
+// This function is similar to the function above. However, the region to be
 // mapped to 2MB pages is specified for this version as hotStart and hotEnd.
-int MapStaticCodeToLargePages(char* hotStart, char* hotEnd) {
-  struct text_region r;
-
-  if (hotStart == nullptr || hotEnd == nullptr || hotStart > hotEnd) {
-    fprintf(stderr, "Hugepages WARNING: Invalid values for hotStart"
-            " and/or hotEnd\n");
-    return -1;
-  }
-
-  r.from = hotStart;
-  r.to = hotEnd;
-
-  return AlignMoveRegionToLargePages(r);
+MapStatus MapStaticCodeToLargePages(void* from, void* to) {
+  return AlignMoveRegionToLargePages(MemRange(from, to));
 }
 
-// Return true if transparent huge pages is enabled on the system. Otherwise,
-// return false.
-bool IsLargePagesEnabled() {
-  return IsTransparentHugePagesEnabled();
+MapStatus IsLargePagesEnabled(bool* result) {
+  return IsTransparentHugePagesEnabled(result);
 }
+
+const string& MapStatusStr(MapStatus status, bool fulltext) {
+  static string map_status_text[] = {
+    "map_ok",
+      "ok",
+    "map_exe_path_read_failed",
+      "failed to read executable path file",
+    "map_failed_to_open_thp_file",
+      "failed to open thp enablement status file",
+    "map_invalid_regex",
+      "invalid regex",
+    "map_invalid_region_address",
+      "invalid region boundaries",
+    "map_malformed_thp_file",
+      "malformed thp enablement status file",
+    "map_malformed_maps_file",
+      "malformed /proc/<PID>/maps file",
+    "map_maps_open_failed",
+      "failed to open maps file",
+    "map_mover_overlaps",
+      "the remapping function is part of the region",
+    "map_null_regex",
+      "regex was NULL",
+    "map_region_not_found",
+      "map region not found",
+    "map_region_too_small",
+      "map region too small",
+    "map_see_errno",
+      "see errno",
+    "map_see_errno_madvise_tmem_failed",
+      "madvise for destination failed",
+    "map_see_errno_madvise_tmem_munmap_nmem_failed",
+      "madvise for destination and unmapping of temporary failed",
+    "map_see_errno_madvise_tmem_munmaps_failed",
+      "madvise for destination and unmappings failed",
+    "map_see_errno_madvise_tmem_munmap_tmem_failed",
+      "madvise for destination and unmapping of destination failed",
+    "map_see_errno_mmap_tmem_failed",
+      "mapping of destination failed",
+    "map_see_errno_mmap_tmem_munmap_nmem_failed",
+      "mapping of destination and unmapping of temporary failed",
+    "map_see_errno_mprotect_failed",
+      "mprotect failed",
+    "map_see_errno_mprotect_munmap_nmem_failed",
+      "mprotect and unmapping of temporary failed",
+    "map_see_errno_mprotect_munmaps_failed",
+      "mprotect and unmappings failed",
+    "map_see_errno_mprotect_munmap_tmem_failed",
+      "mprotect and unmapping of destination failed",
+    "map_see_errno_munmap_nmem_failed",
+      "unmapping of temporary failed"
+  };
+  return map_status_text[(static_cast<int>(status) << 1) + (fulltext & 1)];
+}
+
+}  // namespace largepage

--- a/large_page/large_page.cc
+++ b/large_page/large_page.cc
@@ -277,8 +277,7 @@ MapStatus AlignMoveRegionToLargePages(MemRange r) {
     return status;
   }
 
-  if (r.from > (void*)MoveRegionToLargePages ||
-      r.to <= (void*)MoveRegionToLargePages) {
+  if (r.to <= (void*)MoveRegionToLargePages) {
     return MoveRegionToLargePages(r);
   }
 

--- a/large_page/large_page.h
+++ b/large_page/large_page.h
@@ -20,11 +20,45 @@
 //
 // SPDX-License-Identifier: MIT
 
-#ifndef LARGE_PAGE_H
-#define LARGE_PAGE_H
+#ifndef LARGE_PAGE_H_
+#define LARGE_PAGE_H_
 
-int MapStaticCodeToLargePages();
-int MapStaticCodeToLargePages(char* from, char* to);
-bool IsLargePagesEnabled();
+#include <string>
 
-#endif  // LARGE_PAGE_H:
+namespace largepage {
+    using std::string;
+
+    enum MapStatus {
+        map_ok,
+        map_exe_path_read_failed,
+        map_failed_to_open_thp_file,
+        map_invalid_regex,
+        map_invalid_region_address,
+        map_malformed_thp_file,
+        map_malformed_maps_file,
+        map_maps_open_failed,
+        map_mover_overlaps,
+        map_null_regex,
+        map_region_not_found,
+        map_region_too_small,
+        map_see_errno,
+        map_see_errno_madvise_tmem_failed,
+        map_see_errno_madvise_tmem_munmap_nmem_failed,
+        map_see_errno_madvise_tmem_munmaps_failed,
+        map_see_errno_madvise_tmem_munmap_tmem_failed,
+        map_see_errno_mmap_tmem_failed,
+        map_see_errno_mmap_tmem_munmap_nmem_failed,
+        map_see_errno_mprotect_failed,
+        map_see_errno_mprotect_munmap_nmem_failed,
+        map_see_errno_mprotect_munmaps_failed,
+        map_see_errno_mprotect_munmap_tmem_failed,
+        map_see_errno_munmap_nmem_failed,
+    };
+
+    MapStatus MapStaticCodeToLargePages(const std::string& regexpr = "");
+    MapStatus MapStaticCodeToLargePages(void* from, void* to);
+    MapStatus IsLargePagesEnabled(bool* result);
+    const string& MapStatusStr(MapStatus status, bool fulltext = true);
+};  // namespace largepage
+
+#endif  // LARGE_PAGE_H_

--- a/large_page/ld.implicit.script
+++ b/large_page/ld.implicit.script
@@ -1,10 +1,14 @@
   SECTIONS {
-    .lpstub            : {
-       *libc.a:*(.text .text.*)
-       *(.lpstub)
-     }
+    .text ALIGN(0x200000): {
+      __textsegment = .;
+      *(.text .text.*)
+    }
   }
-  PROVIDE (__textsegment = .);
-  PROVIDE (_textsegment = .);
-  PROVIDE (textsegment = .);
-  INSERT BEFORE .text;
+  INSERT AFTER .init;
+
+  SECTIONS {
+    .lpstub ALIGN(0x200000): {
+       *(.lpstub)
+    }
+  }
+  INSERT AFTER .text;


### PR DESCRIPTION
Port error codes functionality from C implementation.
Port MapStatusStr(error_code), MapStaticCodeToLargePages(lib_regex).
Refactor code following CPP coding standards wherever possible. 
