### PR TITLE
Indicate lack of mapping support at runtime

### DIFF
--- a/detect-platform.mk
+++ b/detect-platform.mk
@@ -1,0 +1,25 @@
+# The conditional definition below allows us to test how the implementation
+# behaves when a value appears that is not supported by giving a value for
+# `ENABLE_LARGE_CODE_PAGES` on the command line.
+ENABLE_LARGE_CODE_PAGES?="detect"
+
+ifeq ($(ENABLE_LARGE_CODE_PAGES), "detect")
+	PLATFORM := $(shell uname -s)
+	ENABLE_LARGE_CODE_PAGES=0
+	ifeq ($(PLATFORM),Linux)
+		ENABLE_LARGE_CODE_PAGES=1
+	endif
+
+# To enable support on more platforms once it's implemented, add more ifeq
+# blocks here, such as the example below:
+#
+#	ifeq ($(PLATFORM),FreeBSD)
+#		ENABLE_LARGE_CODE_PAGES=1
+#	endif
+
+endif
+
+ifneq ($(ENABLE_LARGE_CODE_PAGES), 0)
+	CFLAGS+=-DENABLE_LARGE_CODE_PAGES=$(ENABLE_LARGE_CODE_PAGES)
+	CPPFLAGS+=-DENABLE_LARGE_CODE_PAGES=$(ENABLE_LARGE_CODE_PAGES)
+endif

--- a/large_page-c/Makefile
+++ b/large_page-c/Makefile
@@ -1,17 +1,21 @@
-.PHONY: all
-all: liblarge_page.a
-
+OUTDIR?=.
 CC=gcc
 CFLAGS=-O3 -D_FORTIFY_SOURCE=2 -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
 AR=ar
 RM=/bin/rm
 
+.PHONY: all
+all: $(OUTDIR)/liblarge_page.a
+
+# Append -DENABLE_LARGE_CODE_PAGES=1 to CFLAGS on supported platforms.
+include ../detect-platform.mk
+
 %.o: %.c
 	$(CC) $(CFLAGS) -x c -c $< -o $@
 
-liblarge_page.a: large_page.o
-	$(AR) rcs liblarge_page.a $<
+$(OUTDIR)/liblarge_page.a: large_page.o
+	$(AR) rcs $@ $<
 
 .PHONY: clean
 clean:
-	$(RM) -f *.o *.a
+	$(RM) -f *.o $(OUTDIR)/*.a

--- a/large_page-c/example/Makefile
+++ b/large_page-c/example/Makefile
@@ -1,15 +1,21 @@
 CC=gcc
 CFLAGS?=-O3
-OBJDIR=obj
-OBJS=$(addprefix $(OBJDIR)/,large_page_example.o large_page.o)
+OBJDIR=$(shell realpath obj)
+OBJS=$(addprefix $(OBJDIR)/,large_page_example.o)
 LDFLAGS=-Wl,-T ../ld.implicit.script -Wl,-z,max-page-size=2097152
-VPATH=%.c ..
 
 .PHONY: all
 all: large_page_example
 
-large_page_example: $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) -o $@
+LARGE_PAGE_EXAMPLE_DEPS=    \
+	$(OBJS)                   \
+	$(OBJDIR)/liblarge_page.a \
+
+large_page_example: $(LARGE_PAGE_EXAMPLE_DEPS)
+	$(CC) $(LDFLAGS) $(LARGE_PAGE_EXAMPLE_DEPS) -o $@
+
+$(OBJDIR)/liblarge_page.a:
+	$(MAKE) -C .. OUTDIR=$(OBJDIR)
 
 $(OBJDIR)/%.o : %.c
 	$(CC) $(CFLAGS) -x c -o $@ -c -I.. $<
@@ -20,4 +26,5 @@ $(OBJDIR):
 	@mkdir -p $(OBJDIR)
 
 clean:
+	$(MAKE) -C .. OUTDIR=$(OBJDIR) clean
 	@rm -rf $(OBJDIR) large_page_example

--- a/large_page-c/large_page.c
+++ b/large_page-c/large_page.c
@@ -123,6 +123,7 @@ static map_status FindTextRegion(const char* lib_regex, mem_range* region) {
 }
 
 static map_status IsTransparentHugePagesEnabled(bool* result) {
+#if defined(ENABLE_LARGE_CODE_PAGES) && ENABLE_LARGE_CODE_PAGES
   FILE* ifs;
   char always[16] = {0};
   char madvise[16] = {0};
@@ -151,6 +152,9 @@ static map_status IsTransparentHugePagesEnabled(bool* result) {
   }
 
   return map_ok;
+#else
+  return map_unsupported_platform;
+#endif  // ENABLE_LARGE_CODE_PAGES
 }
 
 // Move specified region to large pages. We need to be very careful.
@@ -380,7 +384,9 @@ const char* MapStatusStr(map_status status, bool fulltext) {
     "map_see_errno_mprotect_munmap_tmem_failed",
       "mprotect and unmapping of destination failed",
     "map_see_errno_munmap_nmem_failed",
-      "unmapping of temporary failed"
+      "unmapping of temporary failed",
+    "map_unsupported_platform",
+      "mapping to large pages is not supported on this platform",
   };
   return map_status_text[((int)status << 1) + (fulltext & 1)];
 }

--- a/large_page-c/large_page.h
+++ b/large_page-c/large_page.h
@@ -50,6 +50,7 @@ typedef enum {
   map_see_errno_mprotect_munmaps_failed,
   map_see_errno_mprotect_munmap_tmem_failed,
   map_see_errno_munmap_nmem_failed,
+  map_unsupported_platform,
 } map_status;
 
 #define MAP_STATUS_STR(status)        MapStatusStr(status, true)

--- a/large_page/Makefile
+++ b/large_page/Makefile
@@ -1,15 +1,21 @@
-all: liblarge_page.a
-
+OUTDIR?=.
 CC=g++
 CFLAGS=-O3 -std=c++11 -D_FORTIFY_SOURCE=2 -fsanitize=address -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
 AR=ar
 RM=/bin/rm
 
+.PHONY: all
+all: $(OUTDIR)/liblarge_page.a
+
+# Append -DENABLE_LARGE_CODE_PAGES=1 to CFLAGS on supported platforms.
+include ../detect-platform.mk
+
 %.o: %.cc
 	$(CC) $(CFLAGS) -c $< -o $@
 
-liblarge_page.a: large_page.o
-	$(AR) rcs liblarge_page.a $<
+$(OUTDIR)/liblarge_page.a: large_page.o
+	$(AR) rcs $@ $<
 
+.PHONY: clean
 clean:
-	$(RM) -f *.o *.a
+	$(RM) -f *.o $(OUTDIR)/*.a

--- a/large_page/example/Makefile
+++ b/large_page/example/Makefile
@@ -1,13 +1,20 @@
-OBJDIR = obj
-OBJS = $(addprefix $(OBJDIR)/,large_page_example.o large_page.o)
 CPPFLAGS=-O3 -std=c++11 -D_FORTIFY_SOURCE=2 -fsanitize=address -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
+OBJDIR=$(shell realpath obj)
+OBJS = $(addprefix $(OBJDIR)/,large_page_example.o)
 LDFLAGS = -Wl,-T ../ld.implicit.script -fsanitize=address
-VPATH =  %.cc ..
 
+.PHONY: all
 all: large_page_example
 
-large_page_example: $(OBJS)
-	@g++ $(OBJS) $(LDFLAGS) -o $@
+LARGE_PAGE_EXAMPLE_DEPS=    \
+	$(OBJS)                   \
+	$(OBJDIR)/liblarge_page.a \
+
+large_page_example: $(LARGE_PAGE_EXAMPLE_DEPS)
+	@g++ $(LARGE_PAGE_EXAMPLE_DEPS) $(LDFLAGS) -o $@
+
+$(OBJDIR)/liblarge_page.a:
+	$(MAKE) -C .. OUTDIR=$(OBJDIR)
 
 $(OBJDIR)/%.o : %.cc
 	@g++ $(CPPFLAGS) -o $@ -c -I.. $<
@@ -18,4 +25,5 @@ $(OBJDIR):
 	@mkdir -p $(OBJDIR)
 
 clean:
+	$(MAKE) -C .. OUTDIR=$(OBJDIR) clean
 	@rm -rf $(OBJDIR) large_page_example

--- a/large_page/large_page.cc
+++ b/large_page/large_page.cc
@@ -128,6 +128,7 @@ MapStatus FindTextRegion(MemRange* region, const string& regexpr = "") {
 }
 
 MapStatus IsTransparentHugePagesEnabled(bool* result) {
+#if defined(ENABLE_LARGE_CODE_PAGES) && ENABLE_LARGE_CODE_PAGES
   *result = false;
   ifstream ifs("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!ifs) {
@@ -155,6 +156,9 @@ MapStatus IsTransparentHugePagesEnabled(bool* result) {
     }
   }
   return map_ok;
+#else
+  return map_unsupported_platform;
+#endif  // ENABLE_LARGE_CODE_PAGES
 }
 
 // Move specified region to large pages. We need to be very careful.
@@ -370,7 +374,9 @@ const string& MapStatusStr(MapStatus status, bool fulltext) {
     "map_see_errno_mprotect_munmap_tmem_failed",
       "mprotect and unmapping of destination failed",
     "map_see_errno_munmap_nmem_failed",
-      "unmapping of temporary failed"
+      "unmapping of temporary failed",
+    "map_unsupported_platform",
+      "mapping to large pages is not supported on this platform",
   };
   return map_status_text[(static_cast<int>(status) << 1) + (fulltext & 1)];
 }

--- a/large_page/large_page.h
+++ b/large_page/large_page.h
@@ -53,6 +53,7 @@ namespace largepage {
         map_see_errno_mprotect_munmaps_failed,
         map_see_errno_mprotect_munmap_tmem_failed,
         map_see_errno_munmap_nmem_failed,
+        map_unsupported_platform,
     };
 
     MapStatus MapStaticCodeToLargePages(const std::string& regexpr = "");


### PR DESCRIPTION
* When building on a supported platform, build support for mapping.
* Otherwise, build a stub that indicates lack of support at runtime.

Re: https://github.com/nodejs/node/pull/30954#discussion_r358696805