### PR TITLE
docs: README: link to the contrib doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,5 @@ Please submit an issue using native github.com interface: https://github.com/int
 
 ## How to contribute
 
-Create a pull request on github.com with your patch. Make sure your change is
-cleanly building. A maintainer will contact you if there are questions or concerns.
-
+Please refer to the [Contributing guide](CONTRIBUTING.md) for details on how to contribute
+to this project.


### PR DESCRIPTION
We have a CONTRIBUTING.md file, but the readme contribuing
section did not link or refer to it. Make it so...

Signed-off-by: Graham Whaley <graham.whaley@intel.com>