### PR TITLE
large pages: use dl_iterate_phdr(3)

### DIFF
--- a/large_page-c/large_page.h
+++ b/large_page-c/large_page.h
@@ -27,13 +27,10 @@
 
 typedef enum {
   map_ok,
-  map_exe_path_read_failed,
   map_failed_to_open_thp_file,
   map_invalid_regex,
   map_invalid_region_address,
   map_malformed_thp_file,
-  map_malformed_maps_file,
-  map_maps_open_failed,
   map_null_regex,
   map_region_not_found,
   map_region_too_small,


### PR DESCRIPTION
Instead of obtaining the executable mapping by reading the
`/proc/self/maps` file, we use `dl_iterate_phdr(3)` to query the
mappings as present in memory and find the one that is loadable,
executable, and contains the reference symbol.