### PR TITLE
large pages: define reference symbol via asm

### DIFF
--- a/large_page-c/example/Makefile
+++ b/large_page-c/example/Makefile
@@ -1,7 +1,14 @@
 CC=gcc
 CFLAGS?=-O3
 OBJDIR=$(shell realpath obj)
+
+# align.o must be the first in the list of object files because it must be the
+# first item passed to the linker. This will ensure that the text section will
+# start at a 2 MiB offset, thus avoiding a scenario where too large a portion of
+# it gets snipped off by the necessity that the region getting remapped to large
+# pages must start at a 2 MiB boundary.
 OBJFILES=              \
+  align.o              \
   large_page_example.o \
   filler1.o            \
   filler2.o            \
@@ -21,7 +28,7 @@ OBJFILES=              \
   filler16.o           \
 
 OBJS=$(addprefix $(OBJDIR)/,$(OBJFILES))
-LDFLAGS=-Wl,-T ../ld.implicit.script -Wl,-z,max-page-size=2097152
+LDFLAGS=-Wl,-z,max-page-size=2097152
 
 .PHONY: all
 all: large_page_example
@@ -35,6 +42,9 @@ large_page_example: $(LARGE_PAGE_EXAMPLE_DEPS)
 
 $(OBJDIR)/liblarge_page.a:
 	$(MAKE) -C .. OUTDIR=$(OBJDIR)
+
+$(OBJDIR)/align.o : align.S
+	gcc -c -o $@ $<
 
 $(OBJDIR)/%.o : %.c
 	$(CC) $(CFLAGS) -x c -o $@ -c -I.. $<

--- a/large_page-c/example/align.S
+++ b/large_page-c/example/align.S
@@ -1,0 +1,5 @@
+.text
+.align 0x200000
+.global __textsegment
+.hidden __textsegment
+  __textsegment:

--- a/large_page-c/ld.implicit.script
+++ b/large_page-c/ld.implicit.script
@@ -1,7 +1,0 @@
-  SECTIONS {
-    .text ALIGN(0x200000): {
-      __textsegment = .;
-      *(.text .text.*)
-    }
-  }
-  INSERT AFTER .init;


### PR DESCRIPTION
We replace the linker script, which is not portable, with an assembly
file that defines a reference symbol to be placed at the beginning of
the .text section. We rely on the fact that the linker tends to place
symbols in the order in which it encounters them and on the fact that
the object file resulting from the assembly file is the first one the
linker encounters to ensure that the symbol is placed early in the text
section.