### PR TITLE
large pages: remove linker flags

### DIFF
--- a/large_page-c/example/Makefile
+++ b/large_page-c/example/Makefile
@@ -28,7 +28,6 @@ OBJFILES=              \
   filler16.o           \
 
 OBJS=$(addprefix $(OBJDIR)/,$(OBJFILES))
-LDFLAGS=-Wl,-z,max-page-size=2097152
 
 .PHONY: all
 all: large_page_example


### PR DESCRIPTION
This removes specialized, and potentially non-portable linker flags.

Re: https://github.com/intel/iodlr/pull/25#discussion_r397787559
Signed-off-by: @gabrielschulhof