### PR TITLE
read ELF .text section header for address and size and create LD_PRELOAD target

### DIFF
--- a/large_page-c/Makefile
+++ b/large_page-c/Makefile
@@ -1,6 +1,8 @@
+include cflags.mk
+
 OUTDIR?=.
 CC=gcc
-CFLAGS=-O3 -D_FORTIFY_SOURCE=2 -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall
+CFLAGS+=$(CFLAGS_COMMON)
 AR=ar
 RM=/bin/rm
 

--- a/large_page-c/Makefile.preload
+++ b/large_page-c/Makefile.preload
@@ -1,0 +1,26 @@
+OUTDIR?=.
+CC=gcc
+CFLAGS=-O3 -D_FORTIFY_SOURCE=2 -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall -shared -fPIC -DPIC
+AR=ar
+RM=/bin/rm
+EXTRA_CFLAGS?=
+
+.PHONY: all
+all: $(OUTDIR)/liblppreload.so
+
+# Append -DENABLE_LARGE_CODE_PAGES=1 to CFLAGS on supported platforms.
+include ../detect-platform.mk
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -x c -c $< -o $@
+
+OBJECTS=\
+  large_page.o \
+  lp_preload.o \
+
+$(OUTDIR)/liblppreload.so: $(OBJECTS)
+	$(CC) -shared -o $@ $(OBJECTS)
+
+.PHONY: clean
+clean:
+	$(RM) -f *.o $(OUTDIR)/*.a

--- a/large_page-c/Makefile.preload
+++ b/large_page-c/Makefile.preload
@@ -1,9 +1,9 @@
+include cflags.mk
 OUTDIR?=.
 CC=gcc
-CFLAGS=-O3 -D_FORTIFY_SOURCE=2 -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall -shared -fPIC -DPIC
+CFLAGS=$(CFLAGS_COMMON) -fPIC -DPIC
 AR=ar
 RM=/bin/rm
-EXTRA_CFLAGS?=
 
 .PHONY: all
 all: $(OUTDIR)/liblppreload.so
@@ -12,7 +12,7 @@ all: $(OUTDIR)/liblppreload.so
 include ../detect-platform.mk
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -x c -c $< -o $@
+	$(CC) $(CFLAGS) -x c -c $< -o $@
 
 OBJECTS=\
   large_page.o \

--- a/large_page-c/Makefile.preload
+++ b/large_page-c/Makefile.preload
@@ -23,4 +23,4 @@ $(OUTDIR)/liblppreload.so: $(OBJECTS)
 
 .PHONY: clean
 clean:
-	$(RM) -f *.o $(OUTDIR)/*.a
+	$(RM) -f *.o $(OUTDIR)/*.so

--- a/large_page-c/cflags.mk
+++ b/large_page-c/cflags.mk
@@ -1,0 +1,1 @@
+CFLAGS_COMMON=-O3 -D_FORTIFY_SOURCE=2 -z noexecstack -z relro -z now -fstack-protector -Wformat -Wformat-security -Wall

--- a/large_page-c/example/Makefile
+++ b/large_page-c/example/Makefile
@@ -36,14 +36,14 @@ large_page_example: $(LARGE_PAGE_EXAMPLE_DEPS)
 $(OBJDIR)/liblarge_page.a:
 	$(MAKE) -C .. OUTDIR=$(OBJDIR)
 
-$(OBJDIR)/%.o : %.c
+$(OBJDIR)/%.o : %.c $(OBJDIR)
 	$(CC) $(CFLAGS) -x c -o $@ -c -I.. $<
 
 $(OBJS): | $(OBJDIR)
 
 $(OBJDIR):
-	@mkdir -p $(OBJDIR)
+	mkdir -p $(OBJDIR)
 
 clean:
 	$(MAKE) -C .. OUTDIR=$(OBJDIR) clean
-	@rm -rf $(OBJDIR) large_page_example
+	rm -rf $(OBJDIR) large_page_example

--- a/large_page-c/example/Makefile
+++ b/large_page-c/example/Makefile
@@ -2,13 +2,7 @@ CC=gcc
 CFLAGS?=-O3
 OBJDIR=$(shell realpath obj)
 
-# align.o must be the first in the list of object files because it must be the
-# first item passed to the linker. This will ensure that the text section will
-# start at a 2 MiB offset, thus avoiding a scenario where too large a portion of
-# it gets snipped off by the necessity that the region getting remapped to large
-# pages must start at a 2 MiB boundary.
 OBJFILES=              \
-  align.o              \
   large_page_example.o \
   filler1.o            \
   filler2.o            \
@@ -41,9 +35,6 @@ large_page_example: $(LARGE_PAGE_EXAMPLE_DEPS)
 
 $(OBJDIR)/liblarge_page.a:
 	$(MAKE) -C .. OUTDIR=$(OBJDIR)
-
-$(OBJDIR)/align.o : align.S
-	gcc -c -o $@ $<
 
 $(OBJDIR)/%.o : %.c
 	$(CC) $(CFLAGS) -x c -o $@ -c -I.. $<

--- a/large_page-c/example/align.S
+++ b/large_page-c/example/align.S
@@ -1,5 +1,0 @@
-.text
-.align 0x200000
-.global __textsegment
-.hidden __textsegment
-  __textsegment:

--- a/large_page-c/large_page.c
+++ b/large_page-c/large_page.c
@@ -47,7 +47,6 @@ typedef struct {
 } FindParams;
 
 #define HPS (2L * 1024 * 1024)
-#define SAFE_DEL(p, func) {if (p) { func(p); p = NULL; }}
 
 static inline uintptr_t largepage_align_down(uintptr_t addr) {
   return (addr & ~(HPS - 1));

--- a/large_page-c/large_page.c
+++ b/large_page-c/large_page.c
@@ -106,7 +106,6 @@ static map_status FindTextSection(const char* fname, ElfW(Shdr)* text_section) {
 }
 
 static int FindMapping(struct dl_phdr_info* hdr, size_t size, void* data) {
-  int idx;
   FindParams* find_params = (FindParams*)data;
   ElfW(Shdr) text_section;
 

--- a/large_page-c/large_page.h
+++ b/large_page-c/large_page.h
@@ -47,6 +47,13 @@ typedef enum {
   map_see_errno_mprotect_munmap_tmem_failed,
   map_see_errno_munmap_nmem_failed,
   map_unsupported_platform,
+  map_open_exe_failed,
+  map_see_errno_close_exe_failed,
+  map_read_exe_header_failed,
+  map_see_errno_seek_exe_sheaders_failed,
+  map_read_exe_sheaders_failed,
+  map_see_errno_seek_exe_string_table_failed,
+  map_read_exe_string_table_failed,
 } map_status;
 
 #define MAP_STATUS_STR(status)        MapStatusStr(status, true)

--- a/large_page-c/lp_preload.c
+++ b/large_page-c/lp_preload.c
@@ -1,27 +1,28 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "large_page.h"
 
 void __attribute__((constructor)) map_to_large_pages() {
-  bool is_enabled;
+  bool is_enabled = true;
   map_status status = IsLargePagesEnabled(&is_enabled);
-  if (status != map_ok) {
-    fprintf(stderr,
-            "Failed to determine if large pages is enabled: %s\n",
-            MapStatusStr(status, true));
-  }
+  if (status != map_ok) goto fail;
 
-  if (!is_enabled) {
-    fprintf(stderr, "Mapping to large pages is not enabled\n");
-    return;
-  }
+  if (!is_enabled) goto fail;
 
   status = MapStaticCodeToLargePages();
-  if (status != map_ok) {
+  if (status != map_ok) goto fail;
+  return;
+fail:
+  if (status == map_ok) {
+    if (!is_enabled)
+      fprintf(stderr,
+              "Mapping to large pages in not enabled on your system. "
+              "Make sure /sys/kernel/mm/transparent_hugepage/enabled is set to "
+              "'madvise' or 'enabled'\n");
+  } else {
     fprintf(stderr,
-            "Failed to map to large pages: %s\n",
+            "Mapping to large pages failed: %s\n",
             MapStatusStr(status, true));
-    return;
   }
-
-  fprintf(stderr, "Successfully mapped code to large pages\n");
+  abort();
 }

--- a/large_page-c/lp_preload.c
+++ b/large_page-c/lp_preload.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include "large_page.h"
+
+void __attribute__((constructor)) map_to_large_pages() {
+  bool is_enabled;
+  map_status status = IsLargePagesEnabled(&is_enabled);
+  if (status != map_ok) {
+    fprintf(stderr,
+            "Failed to determine if large pages is enabled: %s\n",
+            MapStatusStr(status, true));
+  }
+
+  if (!is_enabled) {
+    fprintf(stderr, "Mapping to large pages is not enabled\n");
+    return;
+  }
+
+  status = MapStaticCodeToLargePages();
+  if (status != map_ok) {
+    fprintf(stderr,
+            "Failed to map to large pages: %s\n",
+            MapStatusStr(status, true));
+    return;
+  }
+
+  fprintf(stderr, "Successfully mapped code to large pages\n");
+}

--- a/large_page-c/lp_preload.c
+++ b/large_page-c/lp_preload.c
@@ -24,5 +24,4 @@ fail:
             "Mapping to large pages failed: %s\n",
             MapStatusStr(status, true));
   }
-  abort();
 }


### PR DESCRIPTION
This change removes the need for a special symbol in the target binary. Instead, it reads the binary's ELF section headers to determine the address and size of the `.text` section. This, in turn, allows us to create a LD_PRELOAD library that can be used with any object in any process to attempt to re-map its `.text` section.