### PR TITLE
tools: Add descriptions to metrics help

### DIFF
--- a/tools/measure-perf-metric.sh
+++ b/tools/measure-perf-metric.sh
@@ -65,6 +65,9 @@ function print_metric_array() {
         mod_item="$item [Default]"
       fi
       echo "    - $mod_item"
+      local help_func="help_${item}"
+      local type=`type -t $help_func`
+      [ "$type" == "function" ] && $help_func
     done
   fi
 }

--- a/tools/metric_dsb_cache
+++ b/tools/metric_dsb_cache
@@ -27,6 +27,10 @@ SCRIPTS_DIR=`dirname $0`
 source ${SCRIPTS_DIR}/utils.sh
 echo "ERR: $err_pmus"
 
+function help_dsb_cache() {
+	echo "      Measure front end related data, including MITE, DSB and IFU."
+}
+
 function init_dsb_cache() {
   local local_pmu_array=(idq.dsb_uops idq.ms_uops idq.mite_uops lsd.uops dsb2mite_switches.penalty_cycles cycles)
   local local_pmus

--- a/tools/metric_icache_miss_stalls
+++ b/tools/metric_icache_miss_stalls
@@ -26,6 +26,10 @@
 SCRIPTS_DIR=`dirname $0`
 source ${SCRIPTS_DIR}/utils.sh
 
+function help_icache_miss_stalls() {
+	echo "      Measure icache stall per instruction metrics."
+}
+
 function init_icache_miss_stalls() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions icache_16b.ifdata_stall

--- a/tools/metric_icache_miss_stalls
+++ b/tools/metric_icache_miss_stalls
@@ -34,6 +34,7 @@ function init_icache_miss_stalls() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions icache_16b.ifdata_stall
           "cpu/event=0x80,umask=0x4,cmask=1,edge=1,name=iicache_16b.ifdata_stall:c1:e1/")
+  local local_pmus
   for item in ${local_pmu_array[*]}
   do
     if [ "x${local_pmus}" == "x" ]; then

--- a/tools/metric_itlb_mpki
+++ b/tools/metric_itlb_mpki
@@ -26,6 +26,10 @@
 SCRIPTS_DIR=`dirname $0`
 source ${SCRIPTS_DIR}/utils.sh
 
+function help_itlb_mpki() {
+	echo "      Measure ITLB misses per Kilo-instruction, for 4k and large (2M/1G) pages."
+}
+
 function init_itlb_mpki() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions itlb_misses.walk_completed itlb_misses.walk_completed_4k itlb_misses.walk_completed_2m_4m itlb_misses.walk_completed_1g)

--- a/tools/metric_itlb_mpki
+++ b/tools/metric_itlb_mpki
@@ -33,6 +33,7 @@ function help_itlb_mpki() {
 function init_itlb_mpki() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions itlb_misses.walk_completed itlb_misses.walk_completed_4k itlb_misses.walk_completed_2m_4m itlb_misses.walk_completed_1g)
+  local local_pmus
   for item in ${local_pmu_array[*]}
   do
     if [ "x${local_pmus}" == "x" ]; then

--- a/tools/metric_itlb_stalls
+++ b/tools/metric_itlb_stalls
@@ -26,6 +26,10 @@
 SCRIPTS_DIR=`dirname $0`
 source ${SCRIPTS_DIR}/utils.sh
 
+function help_itlb_stalls() {
+	echo "      Measure percentage of cycles where a code fetch is stalled due to L1 instruction cache tag miss."
+}
+
 function init_itlb_stalls() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions icache_64b.iftag_stall)

--- a/tools/metric_itlb_stalls
+++ b/tools/metric_itlb_stalls
@@ -33,6 +33,7 @@ function help_itlb_stalls() {
 function init_itlb_stalls() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions icache_64b.iftag_stall)
+  local local_pmus
   for item in ${local_pmu_array[*]}
   do
     if [ "x${local_pmus}" == "x" ]; then

--- a/tools/metric_l1_code_read_MPI
+++ b/tools/metric_l1_code_read_MPI
@@ -26,6 +26,10 @@
 SCRIPTS_DIR=`dirname $0`
 source ${SCRIPTS_DIR}/utils.sh
 
+function help_l1_code_read_MPI() {
+	echo "      Measure cache code read (fetch) per-instruction ratio."
+}
+
 function init_l1_code_read_MPI() {
   #Comma seperated perf supported counter names. See example below"
   local local_pmu_array=(instructions l2_rqsts.all_code_rd)

--- a/tools/metric_l2_demand_code_MPI
+++ b/tools/metric_l2_demand_code_MPI
@@ -26,6 +26,10 @@
 SCRIPTS_DIR=`dirname $0`
 source ${SCRIPTS_DIR}/utils.sh
 
+function help_l2_demand_code_MPI() {
+	echo "      Measure cache code read (fetch) misses per-instruction."
+}
+
 function init_l2_demand_code_MPI() {
   local local_pmu_array=(instructions l2_rqsts.code_rd_miss)
   for item in ${local_pmu_array[*]}

--- a/tools/metric_l2_demand_code_MPI
+++ b/tools/metric_l2_demand_code_MPI
@@ -32,6 +32,7 @@ function help_l2_demand_code_MPI() {
 
 function init_l2_demand_code_MPI() {
   local local_pmu_array=(instructions l2_rqsts.code_rd_miss)
+  local local_pmus
   for item in ${local_pmu_array[*]}
   do
     if [ "x${local_pmus}" == "x" ]; then


### PR DESCRIPTION
Add extended 'help' for the metrics, which comes out in the help on the commandline. We can thus expand details on what each metric measure does. The intention is also to add this information to the general repo markdown documents (so folks don't have to go reference the original PDF directly).

Also fix up some minor missing `local` vars.