### PR TITLE
tools: enable pid and command together

### DIFF
--- a/tools/measure-perf-metric.sh
+++ b/tools/measure-perf-metric.sh
@@ -396,13 +396,21 @@ function collect_perf_data() {
   elif [ "${profile_mode}" == "command" ]; then
     # Check if command_name is given to profile
     echo "--------------------------------------------------"
-    echo "Profiling \"${command_name}\""
+    if [ -n "${app_process_id}" ]; then
+      echo "Profiling \"${command_name}\" against PID $app_process_id"
+    else
+      echo "Profiling \"${command_name}\""
+    fi
     echo "--------------------------------------------------"
 
     print_perf_header
     echo "--------------------------------------------------"
 
-    perf ${perf_mode} -o ${PERF_DATA_FILE} -e ${PERF_PMUS} ${command_name}
+    if [ -n "${app_process_id}" ]; then
+      perf ${perf_mode} -o ${PERF_DATA_FILE} -e ${PERF_PMUS} -p $app_process_id ${command_name}
+    else
+      perf ${perf_mode} -o ${PERF_DATA_FILE} -e ${PERF_PMUS} ${command_name}
+    fi
     if [ $? != 0 ]; then
      echo "Perf for $command_name failed. Exiting"
      exit


### PR DESCRIPTION
It can sometimes be useful to run a command (benchmark say), and
monitor a differnet PID (server say). Currently the
measure-perf-metric.sh command only allows one or the other, and
if both are supplied, silintly drops the first.

Enable use of both -p (PID) and -e (command) together, as this is
a valid perf mode.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>