### PR TITLE
Fixing llvm-bolt upstream version to 1.0.1

### DIFF
--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -47,6 +47,9 @@ RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     cd llvm/tools && \
     git checkout -b llvm-bolt f137ed238db11440f03083b1c88b7ffc0f4af65e && \
     git clone https://github.com/facebookincubator/BOLT llvm-bolt && \
+    cd llvm-bolt && \
+    git checkout tags/v1.0.1 && \
+    cd .. && \
     cd .. && \
     patch -p 1 < tools/llvm-bolt/llvm.patch && \
     cd .. && \


### PR DESCRIPTION
Signed-off-by: NitinAtIntel <nitin.tekchandani@intel.com>