### PR TITLE
Add an option to not include an optimization when building the wp-opt/http container

### DIFF
--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -21,10 +21,6 @@
 #
 # SPDX-License-Identifier: MIT
 ARG baseimage=wp_base
-ARG zendlp=1
-ARG bolt=1
-ARG iodlrlp=1
-ARG query=1
 FROM $baseimage
 LABEL authors="nitin.tekchandani@intel.com,lin.a.yang@intel.com,uttam.c.pawar@intel.com"
 
@@ -32,10 +28,10 @@ SHELL ["/bin/bash", "-c"]
 
 COPY files/perf.fdata /home/${USERNAME}/oss-performance
 
-RUN echo "$zendlp" && \
-    echo "$bolt" && \
-    echo "$iodlrlp" && \
-    echo "$query"
+ARG zendlp=1
+ARG bolt=1
+ARG iodlrlp=1
+ARG query=1
 
 # Optimization: Set environment variable to have zend use large pages
 ENV USE_ZEND_ALLOC_HUGE_PAGES="$zendlp" 
@@ -43,7 +39,6 @@ ENV USE_ZEND_ALLOC_HUGE_PAGES="$zendlp"
 # Build php 7.4.16 for bolting
 
 RUN if [[ "$bolt" == "1" ]] ; then \
-    echo "Doing bolt!!" && \
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 && \
     cd /home/${USERNAME}/oss-performance && \
@@ -88,7 +83,6 @@ RUN if [[ "$bolt" == "1" ]] ; then \
 
 # Optimization: Build and install iodlr huge pages library (commit_id: 01f4985) for use with mariadb
 RUN if [[ "$iodlrlp" == "1" ]] ; then \
-    echo "Doing iodlrlp!!" && \
     cd /home/${USERNAME} && \
     git clone https://github.com/intel/iodlr && \
     cd iodlr && \
@@ -102,6 +96,6 @@ RUN if [[ "$iodlrlp" == "1" ]] ; then \
 
 ARG mariadbconf=1s
 # Optimization: Query cache optimization for single socket operation (unless over-ridden)
-RUN if [[ "$query" == "1" ]] ; then echo "Doing query" && sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
+RUN if [[ "$query" == "1" ]] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
 
 WORKDIR /home/${USERNAME}/oss-performance

--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -20,8 +20,6 @@
 # OR OTHER DEALINGS IN THE SOFTWARE.
 #
 # SPDX-License-Identifier: MIT
-SHELL ["/bin/bash", "-c"] 
-
 ARG baseimage=wp_base
 ARG zendlp=1
 ARG bolt=1
@@ -29,6 +27,8 @@ ARG iodlrlp=1
 ARG query=1
 FROM $baseimage
 LABEL authors="nitin.tekchandani@intel.com,lin.a.yang@intel.com,uttam.c.pawar@intel.com"
+
+SHELL ["/bin/bash", "-c"]
 
 COPY files/perf.fdata /home/${USERNAME}/oss-performance
 

--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -35,7 +35,7 @@ ENV USE_ZEND_ALLOC_HUGE_PAGES=${zendlp}
 
 # Build php 7.4.16 for bolting
 
-RUN if [ ${bolt} -eq 1 ] ; then \
+RUN if [ ${bolt} = "1" ] ; then \
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 && \
     cd /home/${USERNAME}/oss-performance && \
@@ -79,7 +79,7 @@ RUN if [ ${bolt} -eq 1 ] ; then \
     fi
 
 # Optimization: Build and install iodlr huge pages library (commit_id: 01f4985) for use with mariadb
-RUN if [ ${iodlrlp} -eq 1 ] ; then \
+RUN if [ ${iodlrlp} = "1" ] ; then \
     cd /home/${USERNAME} && \
     git clone https://github.com/intel/iodlr && \
     cd iodlr && \
@@ -93,6 +93,6 @@ RUN if [ ${iodlrlp} -eq 1 ] ; then \
 
 ARG mariadbconf=1s
 # Optimization: Query cache optimization for single socket operation (unless over-ridden)
-RUN if [ ${query} -eq 1] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
+RUN if [ ${query} = "1" ] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
 
 WORKDIR /home/${USERNAME}/oss-performance

--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -20,6 +20,8 @@
 # OR OTHER DEALINGS IN THE SOFTWARE.
 #
 # SPDX-License-Identifier: MIT
+SHELL ["/bin/bash", "-c"] 
+
 ARG baseimage=wp_base
 ARG zendlp=1
 ARG bolt=1

--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -33,11 +33,11 @@ SHELL ["/bin/bash", "-c"]
 COPY files/perf.fdata /home/${USERNAME}/oss-performance
 
 # Optimization: Set environment variable to have zend use large pages
-ENV USE_ZEND_ALLOC_HUGE_PAGES=${zendlp} 
+ENV USE_ZEND_ALLOC_HUGE_PAGES="$zendlp" 
 
 # Build php 7.4.16 for bolting
 
-RUN if [ ${bolt} = "1" ] ; then \
+RUN if [[ "$bolt" = "1" ]] ; then \
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 && \
     cd /home/${USERNAME}/oss-performance && \
@@ -81,7 +81,7 @@ RUN if [ ${bolt} = "1" ] ; then \
     fi
 
 # Optimization: Build and install iodlr huge pages library (commit_id: 01f4985) for use with mariadb
-RUN if [ ${iodlrlp} = "1" ] ; then \
+RUN if [[ "$iodlrlp" == "1" ]] ; then \
     cd /home/${USERNAME} && \
     git clone https://github.com/intel/iodlr && \
     cd iodlr && \
@@ -95,6 +95,6 @@ RUN if [ ${iodlrlp} = "1" ] ; then \
 
 ARG mariadbconf=1s
 # Optimization: Query cache optimization for single socket operation (unless over-ridden)
-RUN if [ ${query} = "1" ] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
+RUN if [[ "$query" == "1" ]] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
 
 WORKDIR /home/${USERNAME}/oss-performance

--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -32,12 +32,18 @@ SHELL ["/bin/bash", "-c"]
 
 COPY files/perf.fdata /home/${USERNAME}/oss-performance
 
+RUN echo "$zendlp" && \
+    echo "$bolt" && \
+    echo "$iodlrlp" && \
+    echo "$query"
+
 # Optimization: Set environment variable to have zend use large pages
 ENV USE_ZEND_ALLOC_HUGE_PAGES="$zendlp" 
 
 # Build php 7.4.16 for bolting
 
-RUN if [[ "$bolt" = "1" ]] ; then \
+RUN if [[ "$bolt" == "1" ]] ; then \
+    echo "Doing bolt!!" && \
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 && \
     cd /home/${USERNAME}/oss-performance && \
@@ -82,6 +88,7 @@ RUN if [[ "$bolt" = "1" ]] ; then \
 
 # Optimization: Build and install iodlr huge pages library (commit_id: 01f4985) for use with mariadb
 RUN if [[ "$iodlrlp" == "1" ]] ; then \
+    echo "Doing iodlrlp!!" && \
     cd /home/${USERNAME} && \
     git clone https://github.com/intel/iodlr && \
     cd iodlr && \
@@ -95,6 +102,6 @@ RUN if [[ "$iodlrlp" == "1" ]] ; then \
 
 ARG mariadbconf=1s
 # Optimization: Query cache optimization for single socket operation (unless over-ridden)
-RUN if [[ "$query" == "1" ]] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
+RUN if [[ "$query" == "1" ]] ; then echo "Doing query" && sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
 
 WORKDIR /home/${USERNAME}/oss-performance

--- a/containers/wordpress/wp_opt/http/Dockerfile
+++ b/containers/wordpress/wp_opt/http/Dockerfile
@@ -21,16 +21,22 @@
 #
 # SPDX-License-Identifier: MIT
 ARG baseimage=wp_base
+ARG zendlp=1
+ARG bolt=1
+ARG iodlrlp=1
+ARG query=1
 FROM $baseimage
 LABEL authors="nitin.tekchandani@intel.com,lin.a.yang@intel.com,uttam.c.pawar@intel.com"
 
 COPY files/perf.fdata /home/${USERNAME}/oss-performance
 
 # Optimization: Set environment variable to have zend use large pages
-ENV USE_ZEND_ALLOC_HUGE_PAGES=1 
+ENV USE_ZEND_ALLOC_HUGE_PAGES=${zendlp} 
 
 # Build php 7.4.16 for bolting
-RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
+
+RUN if [ ${bolt} -eq 1 ] ; then \
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7 && \
     cd /home/${USERNAME}/oss-performance && \
     git clone https://github.com/php/php-src.git && \
@@ -69,8 +75,11 @@ RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     rm -rf /home/${USERNAME}/oss-performance/llvm && \
     rm -rf /home/${USERNAME}/oss-performance/build && \
 # Cleanup: move php binaries and remove php clone and build files
-    rm -rf /home/${USERNAME}/oss-performance/php-src && \
+    rm -rf /home/${USERNAME}/oss-performance/php-src ; \
+    fi
+
 # Optimization: Build and install iodlr huge pages library (commit_id: 01f4985) for use with mariadb
+RUN if [ ${iodlrlp} -eq 1 ] ; then \
     cd /home/${USERNAME} && \
     git clone https://github.com/intel/iodlr && \
     cd iodlr && \
@@ -79,10 +88,11 @@ RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7 && \
     make -f Makefile.preload && \
     sudo cp liblppreload.so /usr/lib/ && \
     sudo sed -i 's/\/usr\/bin\/mysqld_safe/LD_PRELOAD=\/usr\/lib\/liblppreload.so \/usr\/bin\/mysqld_safe/' /etc/init.d/mysql && \
-    rm -rf /home/${USERNAME}/iodlr/ 
+    rm -rf /home/${USERNAME}/iodlr/ ; \
+    fi
 
 ARG mariadbconf=1s
 # Optimization: Query cache optimization for single socket operation (unless over-ridden)
-RUN sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf
+RUN if [ ${query} -eq 1] ; then sudo cp /home/${USERNAME}/${mariadbconf}-bkm.j2 /etc/mysql/my.cnf ; fi
 
 WORKDIR /home/${USERNAME}/oss-performance


### PR DESCRIPTION
For the wp-opt/http container, if you add  "--build-arg {opt}=0", where opt can be zendlp, bolt, iodlrlp, or query for the four optimizations then it does not build the container with that optimization. Can be useful for A/B testing.