### PR TITLE
Fix grant tables disabled bug

### DIFF
--- a/containers/wordpress/wp_base/http/files/1s-bkm.j2
+++ b/containers/wordpress/wp_base/http/files/1s-bkm.j2
@@ -43,4 +43,4 @@ read_rnd_buffer_size = 8M
 myisam_sort_buffer_size = 64M
 max_connections        = 1000
 myisam-recover         = BACKUP
-skip-grant-tables
+#skip-grant-tables

--- a/containers/wordpress/wp_base/http/files/2s-bkm.j2
+++ b/containers/wordpress/wp_base/http/files/2s-bkm.j2
@@ -49,4 +49,4 @@ tmp_table_size = 1G
 max_heap_table_size = 1G
 max_connections        = 1000
 myisam-recover         = BACKUP
-skip-grant-tables
+#skip-grant-tables


### PR DESCRIPTION
    Mysql cannot use 'password' command as mysqld runs with grant
    tables disabled (was started with --skip-grant-tables). Remove
    skip-grant-tables in 1s-bkm.j2 and 2s-bkm.j2 aka my.cnf in container.
Signed-off-by: PeterYang12 <yuhan.yang@intel.com>