### PR TITLE
Fix the failure of running quickrun.sh. - #48

### DIFF
--- a/containers/wordpress/wp_opt/https/Dockerfile
+++ b/containers/wordpress/wp_opt/https/Dockerfile
@@ -64,4 +64,7 @@ RUN rm -rf ./nginx_build
 WORKDIR /home/${USERNAME}/oss-performance
 
 COPY --chown=${USERNAME}:root files/nginx.conf.in /home/${USERNAME}/oss-performance/conf/nginx
+
+RUN ln -s /home/${USERNAME}/temp/ipp-crypto/sources/ippcp/crypto_mb/build/bin/libcrypto_mb.so.11.1 /usr/lib/libcrypto_mb.so.11
+
 USER ${USERNAME}

--- a/containers/wordpress/wp_opt/https/files/nginx.conf.in
+++ b/containers/wordpress/wp_opt/https/files/nginx.conf.in
@@ -1,6 +1,6 @@
 worker_processes  96; # Depends on #vcpus
 
-load_module /home/base/nginx_install/modules/ngx_ssl_engine_qat_module.so;
+load_module /usr/modules/ngx_ssl_engine_qat_module.so;
 
 error_log __NGINX_TEMP_DIR__/nginx-error.log;
 pid __NGINX_PID_FILE__;


### PR DESCRIPTION
Correct the wrong file path for "load_module" setting in nginx.conf.in.

Create "/usr/lib/libcrypto_mb.so.11" link file, which is needed for
the QAT engine.