### PR TITLE
Add a tool for generating perf map file.

### DIFF
--- a/large_page-c/large_page.c
+++ b/large_page-c/large_page.c
@@ -147,6 +147,7 @@ static int FindMapping(struct dl_phdr_info* hdr, size_t size, void* data) {
         }
       }
       find_params->start = hdr->dlpi_addr + text_section.sh_addr;
+      fprintf(stderr, "Base address: %lx.", hdr->dlpi_addr);
       find_params->end = find_params->start + text_section.sh_size;
       return 1;
     }

--- a/large_page-c/lp_preload.c
+++ b/large_page-c/lp_preload.c
@@ -7,6 +7,8 @@
 #include <regex.h>
 #include "large_page.h"
 
+pid_t gettid(void);
+
 void printErr (map_status status, const char * lib) {
   fprintf(stderr,
     "Mapping to large pages failed for %s: %s\n", lib,
@@ -37,6 +39,7 @@ static int tryMapAllDSOs(struct dl_phdr_info* hdr, size_t size, void* data) {
 
 void __attribute__((constructor)) map_to_large_pages() {
   bool is_enabled = true;
+  fprintf(stderr, "TID: %d\n:", gettid());
   map_status status = IsLargePagesEnabled(&is_enabled);
   if (status != map_ok) goto fail;
 

--- a/tools/gen-perf-map.sh
+++ b/tools/gen-perf-map.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+if [ "$#" -lt 3 ]; then
+    echo "Usage: $0 LIB BASEADDRESS TID"
+    exit 1
+fi
+
+nm -DSC $1 | grep " [TVWu] " | awk '{$3=""; print$0}' > nm-output.txt
+
+./maps_file.py $2
+
+cat ./tmp.map >> "/tmp/perf-$3.map"
+
+rm ./nm-output.txt ./tmp.map
+echo "Generated /tmp/perf-$3.map"

--- a/tools/maps_file.py
+++ b/tools/maps_file.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+import sys
+
+class MapsFile:
+    def __init__(self, name):
+        self.name = name
+        self.lines = []
+
+    def write_file(self, name):
+        with open(name, "w") as file:
+            for line in self.lines:
+                file.write("%s %s\n" % (line[0], line[1]))
+    
+    def calculate_vir_adr(self, baseaddr):
+        with open(self.name) as file:
+            for line in file:
+                larray = line.rstrip().split(" ", 1)
+                larray[0] = "%016lx" % (int(larray[0], 16) + baseaddr)
+                self.lines.append(larray)
+                
+
+if __name__ == "__main__":
+    src = "./nm-output.txt"
+    dest = "./tmp.map"
+    fd = MapsFile(src)
+    
+    fd.calculate_vir_adr(int(sys.argv[1], 16))
+
+    fd.write_file(dest)


### PR DESCRIPTION
Add it so that perf can show symbols correctly after .txt section is re-mapped into huge page.

Usage:
  gen-perf-map.sh LIB BASEADDRESS TID

If there are several .so files mapped into huge page, the script needs to be run several times.

Also, add some codes to print base address and tid on console, which is needed for running the tool.

Fix #76

Signed-off-by: Leiw <steven.l.wang@linux.intel.com>