### PR TITLE
gen-perf-map: Use nm -aSC

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -79,8 +79,10 @@ When huge page is enabled and the .txt sections are mapped into it, Perf are no 
 
 ## Usage
 ```
-./gen-perf-map.sh LIB BASEADDRESS TID
+./gen-perf-map.sh -s|-b PATH BASEADDRESS TID
 ```
+* -s|-b: Pass -s if generating symbols for a dynamic library or -b if passing a binary
+* PATH: Path to the shared library or binary
 * TID: thread ID
 * BASEADDRESS: beginning address of .txt section in huge page.
 
@@ -113,5 +115,5 @@ Enabling large code pages for /lib/x86_64-linux-gnu/libc.so.6 Base address: 7f36
 
 Run "gen-perf-map.sh" to generate the perf map file under /tmp/:
 ```
-./gen-perf-map.sh /lib/x86_64-linux-gnu/libnode.so.64 7f36633c3000 8817
+./gen-perf-map.sh -s /lib/x86_64-linux-gnu/libnode.so.64 7f36633c3000 8817
 ```

--- a/tools/gen-perf-map.sh
+++ b/tools/gen-perf-map.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/bash
 
-if [ "$#" -lt 3 ]; then
-    echo "Usage: $0 LIB BASEADDRESS TID"
+if [ "$#" -lt 4 ]; then
+    echo "Usage: $0 -s|-b PATH BASEADDRESS TID"
     exit 1
 fi
 
-nm -aSC $1 | grep " [TtVWu] " | awk '{$3=""; print$0}' > nm-output.txt
+if [ "$1" = "-s" ]; then
+    NM_ARGS="-DSC"
+elif [ "$1" = "-b" ]; then
+    NM_ARGS="-aSC"
+else
+    echo "Pass either -s (shared lib) or -b (binary)"
+    exit 1
+fi
 
-./maps_file.py $2
+nm $NM_ARGS $2 | grep " [TtVWu] " | awk '{$3=""; print$0}' > nm-output.txt
 
-cat ./tmp.map >> "/tmp/perf-$3.map"
+./maps_file.py $3
+
+cat ./tmp.map >> "/tmp/perf-$4.map"
 
 rm ./nm-output.txt ./tmp.map
-echo "Generated /tmp/perf-$3.map"
+echo "Generated /tmp/perf-$4.map"

--- a/tools/gen-perf-map.sh
+++ b/tools/gen-perf-map.sh
@@ -5,7 +5,7 @@ if [ "$#" -lt 3 ]; then
     exit 1
 fi
 
-nm -DSC $1 | grep " [TVWu] " | awk '{$3=""; print$0}' > nm-output.txt
+nm -aSC $1 | grep " [TtVWu] " | awk '{$3=""; print$0}' > nm-output.txt
 
 ./maps_file.py $2
 


### PR DESCRIPTION
This makes `nm` list debug symbols and as a consequence make `gen-perf-map` generate perf maps with symbols for those.

Without this the script was not generating meaningful perf map files for binaries.

Also make the grep respect lowercase `t`s which makes the grep work for non external functions.