### PR TITLE
gen-perf-script: Refer to maps_file script in relative fashion

### DIFF
--- a/tools/gen-perf-map.sh
+++ b/tools/gen-perf-map.sh
@@ -16,7 +16,7 @@ fi
 
 nm $NM_ARGS $2 | grep " [TtVWu] " | awk '{$3=""; print$0}' > nm-output.txt
 
-./maps_file.py $3
+$( dirname -- "$0"; )/maps_file.py $3
 
 cat ./tmp.map >> "/tmp/perf-$4.map"
 


### PR DESCRIPTION
Call `maps_file.py` subscript in a relative fashion to the `gen-perf-script` script. Otherwise it can only be run from the tools subdir which isn't really that great.